### PR TITLE
描いた線を写真アプリに保存する機能を追加

### DIFF
--- a/PencilKitDemo/PencilKitDemo.xcodeproj/project.pbxproj
+++ b/PencilKitDemo/PencilKitDemo.xcodeproj/project.pbxproj
@@ -7,8 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C0F1DB72AA2E46F002D1AE5 /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DB62AA2E46F002D1AE5 /* ImageSaver.swift */; };
+		4C0F1DB92AA2EA8E002D1AE5 /* ToastModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DB82AA2EA8E002D1AE5 /* ToastModifier.swift */; };
 		4C0F1DBC2AA30460002D1AE5 /* ErrorMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */; };
 		4C0F1DBE2AA30481002D1AE5 /* ConfirmMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */; };
+		4C0F1DC02AA30CB6002D1AE5 /* SaveConfirmMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DBF2AA30CB6002D1AE5 /* SaveConfirmMessageModel.swift */; };
+		4C0F1DC42AA319C8002D1AE5 /* ToastMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DC32AA319C8002D1AE5 /* ToastMessageModel.swift */; };
 		4C1482282A8E076700947877 /* PencilKitDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482272A8E076700947877 /* PencilKitDemoApp.swift */; };
 		4C14822A2A8E076700947877 /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482292A8E076700947877 /* DrawingView.swift */; };
 		4C14822C2A8E076A00947877 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C14822B2A8E076A00947877 /* Assets.xcassets */; };
@@ -18,11 +22,16 @@
 		4C1482492A8F0E9E00947877 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482482A8F0E9E00947877 /* ContentView.swift */; };
 		4C14824B2A8F1C1800947877 /* ProgressModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C14824A2A8F1C1800947877 /* ProgressModifier.swift */; };
 		4C3B2EB62A918A5700F733C0 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B2EB52A918A5700F733C0 /* ViewExtension.swift */; };
+		4C3B2EB82A91979600F733C0 /* SaveConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B2EB72A91979600F733C0 /* SaveConfirmationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4C0F1DB62AA2E46F002D1AE5 /* ImageSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSaver.swift; sourceTree = "<group>"; };
+		4C0F1DB82AA2EA8E002D1AE5 /* ToastModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastModifier.swift; sourceTree = "<group>"; };
 		4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageModel.swift; sourceTree = "<group>"; };
 		4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmMessageModel.swift; sourceTree = "<group>"; };
+		4C0F1DBF2AA30CB6002D1AE5 /* SaveConfirmMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveConfirmMessageModel.swift; sourceTree = "<group>"; };
+		4C0F1DC32AA319C8002D1AE5 /* ToastMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastMessageModel.swift; sourceTree = "<group>"; };
 		4C1482242A8E076700947877 /* PencilKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PencilKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C1482272A8E076700947877 /* PencilKitDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PencilKitDemoApp.swift; sourceTree = "<group>"; };
 		4C1482292A8E076700947877 /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
@@ -33,6 +42,7 @@
 		4C1482482A8F0E9E00947877 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4C14824A2A8F1C1800947877 /* ProgressModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressModifier.swift; sourceTree = "<group>"; };
 		4C3B2EB52A918A5700F733C0 /* ViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
+		4C3B2EB72A91979600F733C0 /* SaveConfirmationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveConfirmationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +61,8 @@
 			children = (
 				4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */,
 				4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */,
+				4C0F1DBF2AA30CB6002D1AE5 /* SaveConfirmMessageModel.swift */,
+				4C0F1DC32AA319C8002D1AE5 /* ToastMessageModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -108,6 +120,7 @@
 				4C3B2EB42A918A4000F733C0 /* Extensions */,
 				4C1482522A8F53FC00947877 /* Modifiers */,
 				4C1482512A8F53E800947877 /* Views */,
+				4C0F1DB62AA2E46F002D1AE5 /* ImageSaver.swift */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -116,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				4C1482352A8E317200947877 /* PencilKitView.swift */,
+				4C3B2EB72A91979600F733C0 /* SaveConfirmationView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -124,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				4C14824A2A8F1C1800947877 /* ProgressModifier.swift */,
+				4C0F1DB82AA2EA8E002D1AE5 /* ToastModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -206,15 +221,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C3B2EB82A91979600F733C0 /* SaveConfirmationView.swift in Sources */,
 				4C14822A2A8E076700947877 /* DrawingView.swift in Sources */,
 				4C1482362A8E317200947877 /* PencilKitView.swift in Sources */,
 				4C0F1DBC2AA30460002D1AE5 /* ErrorMessageModel.swift in Sources */,
 				4C0F1DBE2AA30481002D1AE5 /* ConfirmMessageModel.swift in Sources */,
 				4C1482402A8EF65B00947877 /* DrawingViewModel.swift in Sources */,
+				4C0F1DB72AA2E46F002D1AE5 /* ImageSaver.swift in Sources */,
+				4C0F1DC02AA30CB6002D1AE5 /* SaveConfirmMessageModel.swift in Sources */,
 				4C3B2EB62A918A5700F733C0 /* ViewExtension.swift in Sources */,
 				4C14824B2A8F1C1800947877 /* ProgressModifier.swift in Sources */,
 				4C1482492A8F0E9E00947877 /* ContentView.swift in Sources */,
+				4C0F1DB92AA2EA8E002D1AE5 /* ToastModifier.swift in Sources */,
 				4C1482282A8E076700947877 /* PencilKitDemoApp.swift in Sources */,
+				4C0F1DC42AA319C8002D1AE5 /* ToastMessageModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -346,6 +366,7 @@
 				DEVELOPMENT_TEAM = D8895LUF5C;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "描画した内容を写真にアクセスして保存します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -375,6 +396,7 @@
 				DEVELOPMENT_TEAM = D8895LUF5C;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "描画した内容を写真にアクセスして保存します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PencilKitDemo/PencilKitDemo.xcodeproj/project.pbxproj
+++ b/PencilKitDemo/PencilKitDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C0F1DBC2AA30460002D1AE5 /* ErrorMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */; };
+		4C0F1DBE2AA30481002D1AE5 /* ConfirmMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */; };
 		4C1482282A8E076700947877 /* PencilKitDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482272A8E076700947877 /* PencilKitDemoApp.swift */; };
 		4C14822A2A8E076700947877 /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482292A8E076700947877 /* DrawingView.swift */; };
 		4C14822C2A8E076A00947877 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C14822B2A8E076A00947877 /* Assets.xcassets */; };
@@ -15,9 +17,12 @@
 		4C1482402A8EF65B00947877 /* DrawingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C14823F2A8EF65B00947877 /* DrawingViewModel.swift */; };
 		4C1482492A8F0E9E00947877 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1482482A8F0E9E00947877 /* ContentView.swift */; };
 		4C14824B2A8F1C1800947877 /* ProgressModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C14824A2A8F1C1800947877 /* ProgressModifier.swift */; };
+		4C3B2EB62A918A5700F733C0 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3B2EB52A918A5700F733C0 /* ViewExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageModel.swift; sourceTree = "<group>"; };
+		4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmMessageModel.swift; sourceTree = "<group>"; };
 		4C1482242A8E076700947877 /* PencilKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PencilKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C1482272A8E076700947877 /* PencilKitDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PencilKitDemoApp.swift; sourceTree = "<group>"; };
 		4C1482292A8E076700947877 /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
@@ -27,6 +32,7 @@
 		4C14823F2A8EF65B00947877 /* DrawingViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawingViewModel.swift; sourceTree = "<group>"; };
 		4C1482482A8F0E9E00947877 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4C14824A2A8F1C1800947877 /* ProgressModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressModifier.swift; sourceTree = "<group>"; };
+		4C3B2EB52A918A5700F733C0 /* ViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,6 +46,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4C0F1DBA2AA2F7F6002D1AE5 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				4C0F1DBD2AA30481002D1AE5 /* ConfirmMessageModel.swift */,
+				4C0F1DBB2AA30460002D1AE5 /* ErrorMessageModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		4C14821B2A8E076700947877 = {
 			isa = PBXGroup;
 			children = (
@@ -89,6 +104,8 @@
 		4C14824F2A8F44CC00947877 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				4C0F1DBA2AA2F7F6002D1AE5 /* Models */,
+				4C3B2EB42A918A4000F733C0 /* Extensions */,
 				4C1482522A8F53FC00947877 /* Modifiers */,
 				4C1482512A8F53E800947877 /* Views */,
 			);
@@ -109,6 +126,14 @@
 				4C14824A2A8F1C1800947877 /* ProgressModifier.swift */,
 			);
 			path = Modifiers;
+			sourceTree = "<group>";
+		};
+		4C3B2EB42A918A4000F733C0 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4C3B2EB52A918A5700F733C0 /* ViewExtension.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -183,7 +208,10 @@
 			files = (
 				4C14822A2A8E076700947877 /* DrawingView.swift in Sources */,
 				4C1482362A8E317200947877 /* PencilKitView.swift in Sources */,
+				4C0F1DBC2AA30460002D1AE5 /* ErrorMessageModel.swift in Sources */,
+				4C0F1DBE2AA30481002D1AE5 /* ConfirmMessageModel.swift in Sources */,
 				4C1482402A8EF65B00947877 /* DrawingViewModel.swift in Sources */,
+				4C3B2EB62A918A5700F733C0 /* ViewExtension.swift in Sources */,
 				4C14824B2A8F1C1800947877 /* ProgressModifier.swift in Sources */,
 				4C1482492A8F0E9E00947877 /* ContentView.swift in Sources */,
 				4C1482282A8E076700947877 /* PencilKitDemoApp.swift in Sources */,

--- a/PencilKitDemo/PencilKitDemo/Drawing/DrawingView.swift
+++ b/PencilKitDemo/PencilKitDemo/Drawing/DrawingView.swift
@@ -30,27 +30,13 @@ struct DrawingView: View {
             }
             .ignoresSafeArea(.all)
             .progressing(viewModel.showProgress)
-            .alert(
-                "Error",
-                isPresented: $viewModel.showError,
-                actions: {},
-                message: {
-                    Text(viewModel.errorMessage)
-                }
+            .errorMessage(
+                $viewModel.errorMessageModel.show,
+                model: viewModel.errorMessageModel
             )
-            .alert(
-                "Warning",
-                isPresented: $viewModel.showConfirm,
-                actions: {
-                    Button(role: .destructive) {
-                        dismiss()
-                    } label: {
-                        Text("OK")
-                    }
-                },
-                message: {
-                    Text(viewModel.confirmMessage)
-                }
+            .confirmMessage(
+                $viewModel.confirmMessageModel.show,
+                model: viewModel.confirmMessageModel
             )
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarLeading) {

--- a/PencilKitDemo/PencilKitDemo/Drawing/DrawingView.swift
+++ b/PencilKitDemo/PencilKitDemo/Drawing/DrawingView.swift
@@ -29,7 +29,6 @@ struct DrawingView: View {
                     }
             }
             .ignoresSafeArea(.all)
-            .progressing(viewModel.showProgress)
             .errorMessage(
                 $viewModel.errorMessageModel.show,
                 model: viewModel.errorMessageModel
@@ -38,6 +37,10 @@ struct DrawingView: View {
                 $viewModel.confirmMessageModel.show,
                 model: viewModel.confirmMessageModel
             )
+            .sheet(isPresented: $viewModel.saveConfirmMessageModel.show) {
+                SaveConfirmationView(model: viewModel.saveConfirmMessageModel)
+                    .presentationDetents([ .fraction(0.4), .fraction(0.75) ])
+            }
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarLeading) {
                     HStack {
@@ -48,7 +51,7 @@ struct DrawingView: View {
                     HStack(spacing: 2.5) {
                         toolButton
                         saveButton
-                        restartButton
+                        restoreButton
                         pauseButton
                         undoButton
                         redoButton
@@ -58,6 +61,8 @@ struct DrawingView: View {
                 }
             }
         }
+        .progressing(viewModel.showProgress)
+        .toast(viewModel.toastMessageModel)
     }
 }
 
@@ -82,15 +87,15 @@ private extension DrawingView {
     /// Save to Album
     var saveButton: some View {
         Button {
-            viewModel.saveToAlbum()
+            viewModel.saveToAlbum(baseImage: baseImage)
         } label: {
             Image(systemName: "camera.circle")
         }
     }
-    /// 再開用
-    var restartButton: some View {
+    /// 復元用
+    var restoreButton: some View {
         Button {
-            viewModel.restart()
+            viewModel.restore()
         } label: {
             Image(systemName: "play.circle")
         }
@@ -122,7 +127,7 @@ private extension DrawingView {
     /// Trash
     var trashButton: some View {
         Button {
-            viewModel.canvasView.drawing = PKDrawing()
+            viewModel.trash()
         } label: {
             Image(systemName: "trash.circle")
         }

--- a/PencilKitDemo/PencilKitDemo/Drawing/DrawingViewModel.swift
+++ b/PencilKitDemo/PencilKitDemo/Drawing/DrawingViewModel.swift
@@ -214,20 +214,25 @@ private extension DrawingViewModel {
                     errorMessageModel.show = true
                     return
                 }
-                toastMessageModel.message = "Saving is complete."
-                toastMessageModel.show = true
-                toastMessageModel.tapped = {
-                    withAnimation(.easeOut(duration: 0.2)) {
-                        self.toastMessageModel.show = false
-                    }
-                }
-                Task {
-                    try await Task.sleep(for: .seconds(5))
-                    withAnimation(.easeOut(duration: 0.2)) {
-                        self.toastMessageModel.show = false
-                    }
-                }
+                showSavedToast()
                 showProgress = false
+            }
+        }
+    }
+
+    @MainActor
+    func showSavedToast() {
+        toastMessageModel.message = "Saving is complete."
+        toastMessageModel.show = true
+        toastMessageModel.tapped = {
+            withAnimation(.easeOut(duration: 0.2)) {
+                self.toastMessageModel.show = false
+            }
+        }
+        Task {
+            try await Task.sleep(for: .seconds(5))
+            withAnimation(.easeOut(duration: 0.2)) {
+                self.toastMessageModel.show = false
             }
         }
     }

--- a/PencilKitDemo/PencilKitDemo/Modules/Extensions/ViewExtension.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Extensions/ViewExtension.swift
@@ -1,0 +1,38 @@
+//
+//  ViewExtension.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/08/18.
+//
+
+import SwiftUI
+
+extension View {
+
+    func errorMessage(_ show: Binding<Bool>, model: ErrorMessageModel) -> some View {
+        self.alert(
+            model.title,
+            isPresented: show,
+            actions: {},
+            message: { Text(model.message) }
+        )
+    }
+
+    func confirmMessage(_ show: Binding<Bool>, model: ConfirmMessageModel) -> some View {
+        self.alert(
+            model.title,
+            isPresented: show,
+            actions: {
+                Button(role: .cancel, action: {}, label: { Text("Cancel") })
+                Button(role: model.rightButtonRole) {
+                    model.action?()
+                } label: {
+                    Text(model.rightButtonTitle)
+                }
+            },
+            message: {
+                Text(model.message)
+            }
+        )
+    }
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/ImageSaver.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/ImageSaver.swift
@@ -1,0 +1,59 @@
+//
+//  ImageSaver.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import UIKit
+
+final class ImageSaver: NSObject {
+
+    let baseImage: UIImage
+    let drawnImage: UIImage
+
+    private var savedContinuation: CheckedContinuation<Error?, Never>?
+
+    init(baseImage: UIImage, drawnImage: UIImage) {
+        self.baseImage = baseImage
+        self.drawnImage = drawnImage
+    }
+
+    func writeDrawnImageToPhotoAlbum() async -> Error? {
+        return await withCheckedContinuation { continuation in
+            savedContinuation = continuation
+            UIImageWriteToSavedPhotosAlbum(drawnImage, self, #selector(saveCompleted), nil)
+        }
+    }
+
+    func writeCombinedImageToPhotoAlbum() async -> Error? {
+        return await withCheckedContinuation { continuation in
+            savedContinuation = continuation
+            let image: UIImage = baseImage.combine(image: drawnImage)
+            UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveCompleted), nil)
+        }
+    }
+}
+
+private extension ImageSaver {
+
+    @objc private func saveCompleted(
+        _ image: UIImage,
+        didFinishSavingWithError error: Error?,
+        contextInfo: UnsafeRawPointer
+    ) {
+        savedContinuation?.resume(returning: error)
+    }
+}
+
+private extension UIImage {
+
+    func combine(image: UIImage) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        draw(in: CGRect(origin: .zero, size: size))
+        image.draw(in: CGRect(origin: .zero, size: image.size))
+        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return image
+    }
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/Models/ConfirmMessageModel.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Models/ConfirmMessageModel.swift
@@ -1,0 +1,17 @@
+//
+//  ConfirmMessageModel.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import SwiftUI
+
+struct ConfirmMessageModel {
+    var show: Bool = false
+    var title: String = ""
+    var message: String = ""
+    var rightButtonRole: ButtonRole?
+    var rightButtonTitle: String = "OK"
+    var action: (() -> Void)?
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/Models/ErrorMessageModel.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Models/ErrorMessageModel.swift
@@ -1,0 +1,14 @@
+//
+//  ErrorMessageModel.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import Foundation
+
+struct ErrorMessageModel {
+    var show: Bool = false
+    var title: String = ""
+    var message: String = ""
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/Models/SaveConfirmMessageModel.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Models/SaveConfirmMessageModel.swift
@@ -1,0 +1,20 @@
+//
+//  SaveConfirmMessageModel.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import Foundation
+
+struct SaveConfirmMessageModel {
+    var show: Bool = false
+    var message: String = ""
+    var selected: ((SaveConfirmMessageResponseType) -> Void)?
+}
+
+enum SaveConfirmMessageResponseType {
+    case drawnImage
+    case combinedImage
+    case cancel
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/Models/ToastMessageModel.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Models/ToastMessageModel.swift
@@ -1,0 +1,14 @@
+//
+//  ToastMessageModel.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import Foundation
+
+struct ToastMessageModel {
+    var show: Bool = false
+    var message: String = ""
+    var tapped: (() -> Void)?
+}

--- a/PencilKitDemo/PencilKitDemo/Modules/Modifiers/ProgressModifier.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Modifiers/ProgressModifier.swift
@@ -11,6 +11,9 @@ struct ProgressModifier: ViewModifier {
 
     let show: Bool
 
+    @State private var opacityOverlay = 0.0
+    @State private var opacityContent = 0.0
+
     func body(content: Content) -> some View {
         ZStack {
             content.allowsHitTesting(!show)
@@ -20,7 +23,13 @@ struct ProgressModifier: ViewModifier {
                     .fill(.black)
                     .opacity(0.5)
                     .ignoresSafeArea()
-                
+                    .opacity(opacityOverlay)
+                    .onAppear {
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            opacityOverlay = 1.0
+                        }
+                    }
+
                 VStack(spacing: 10) {
                     ProgressView()
                     Text("Loading...")
@@ -31,9 +40,16 @@ struct ProgressModifier: ViewModifier {
                     RoundedRectangle(cornerRadius: 20)
                         .fill(Color(uiColor: .systemGray6))
                 }
-                .offset(y: -50)
+                .offset(y: -20)
+                .opacity(opacityContent)
+                .onAppear {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        opacityContent = 1.0
+                    }
+                }
             }
         }
+        .ignoresSafeArea(.all)
     }
 }
 

--- a/PencilKitDemo/PencilKitDemo/Modules/Modifiers/ToastModifier.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Modifiers/ToastModifier.swift
@@ -1,0 +1,76 @@
+//
+//  ToastModifier.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/09/02.
+//
+
+import SwiftUI
+
+struct ToastModifier: ViewModifier {
+
+    let model: ToastMessageModel
+
+    @State private var opacityContent = 0.0
+
+    func body(content: Content) -> some View {
+        content.safeAreaInset(edge: .bottom) {
+            if model.show {
+                HStack {
+                    Text(model.message)
+                        .multilineTextAlignment(.leading)
+                        .font(.caption)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(20)
+                        .background {
+                            RoundedRectangle(cornerRadius: 20)
+                                .fill(Color(uiColor: .systemGray6).opacity(0.95))
+                        }
+                }
+                .padding([.horizontal], 20)
+                .offset(y: -10)
+                .opacity(opacityContent)
+                .onAppear {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        opacityContent = 1.0
+                    }
+                }
+                .onTapGesture {
+                    model.tapped?()
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    func toast(_ model: ToastMessageModel) -> some View {
+        modifier(ToastModifier(model: model))
+    }
+}
+
+#if DEBUG
+struct ToastModifierContentView: View {
+    var body: some View {
+        ZStack {
+            Color.blue.ignoresSafeArea()
+            Text("Hello, World!")
+        }
+        .toast(
+            ToastMessageModel(
+                show: true,
+                message: """
+                    Sample Sample Sample Sample Sample Sample Sample Sample
+                    Sample Sample Sample Sample Sample Sample Sample Sample Sample Sample Sample
+                    """
+            )
+        )
+    }
+}
+
+struct ToastModifier_Previews: PreviewProvider {
+    static var previews: some View {
+        ToastModifierContentView()
+    }
+}
+#endif

--- a/PencilKitDemo/PencilKitDemo/Modules/Views/SaveConfirmationView.swift
+++ b/PencilKitDemo/PencilKitDemo/Modules/Views/SaveConfirmationView.swift
@@ -1,0 +1,85 @@
+//
+//  SaveConfirmationView.swift
+//  PencilKitDemo
+//
+//  Created by Masakiyo Tachikawa on 2023/08/17.
+//
+
+import PencilKit
+import SwiftUI
+
+struct SaveConfirmationView: View {
+
+    let model: SaveConfirmMessageModel
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 20) {
+                Text(model.message)
+                    .font(.caption)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding([.top, .horizontal], 30)
+
+                VStack(spacing: 0) {
+                    Divider()
+
+                    Button("Save just the drawn image") {
+                        model.selected?(.drawnImage)
+                    }
+                    .buttonStyle(FullWidthButtonStyle())
+
+                    Divider()
+
+                    Button("Save also the background image") {
+                        model.selected?(.combinedImage)
+                    }
+                    .buttonStyle(FullWidthButtonStyle())
+
+                    Divider()
+
+                    Button("Cancel") {
+                        model.selected?(.cancel)
+                    }
+                    .buttonStyle(FullWidthButtonStyle(isCancel: true))
+
+                    Divider()
+
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .scrollBounceBehavior(.basedOnSize)
+    }
+}
+
+private struct FullWidthButtonStyle: ButtonStyle {
+
+    let isCancel: Bool
+
+    init(isCancel: Bool = false) {
+        self.isCancel = isCancel
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding([.vertical], 15)
+            .frame(maxWidth: .infinity)
+            .foregroundColor(Color(uiColor: .systemBlue))
+            .font(.callout)
+            .fontWeight(isCancel ? .bold : .regular)
+            .background(
+                configuration.isPressed
+                ? Color(uiColor: .systemGray5)
+                : Color(uiColor: .systemBackground)
+            )
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+struct SaveConfirmationView_Previews: PreviewProvider {
+    static var previews: some View {
+        SaveConfirmationView(model: .init())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@ SwiftUIで動かしたかったので `PKCanvasView` は `UIViewRepresentable` �
 
 書き込み画面には、とりあえず使いそうな操作（UndoやRedoなど）を確認するためのボタンを上部に配置。　　
 
+写真アプリへ保存する機能は「描いたもののみ」と「画像と描いたもの両方」を選択可能。
+
 ### メモ
 
-「アルバム保存」（カメラボタン）と「ヘルプ」（？ボタン）は未実装。　　
+「ヘルプ」（？ボタン）は未実装。　　
 
 ### Sample Video
 
-<kbd><img src="https://github.com/MTattin/PencilKitDemo/assets/2594225/57378f64-efc1-478b-a63b-6f7bf30b33d1" /></kbd>
+| Sample 1 | Sample 2 (Save function) |
+|-----|-----|
+| <kbd><img src="https://github.com/MTattin/PencilKitDemo/assets/2594225/57378f64-efc1-478b-a63b-6f7bf30b33d1" /></kbd> | <kbd><img src="https://github.com/MTattin/PencilKitDemo/assets/2594225/f1c35857-aca3-4dea-993b-fdc80611793f)" /></kbd> |
+
 
 ## References
 


### PR DESCRIPTION
## やったこと

* Errorや確認ダイアログ用のModelを作成してコードをリファクタ
* 描画内容を写真アプリに保存できる機能を追加

## 変わること

### できるようになること

* カメラのボタンをタップしたら描画内容を写真アプリに保存できるようになる
* Draw画面へ遷移した際に前回の描画を表示するかの確認ダイアログが表示されるようになる

## 動作確認

Simulatorで動作確認

## その他

特になし
